### PR TITLE
Simplified /login routes by eliminating jwt

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,10 +1,5 @@
-const jwt = require('jsonwebtoken')
 const tokenDAO = require("../daos/token");
 const userDAO = require("../daos/users");
-
-// TODO: Maybe put this in a .env file? We can wait until we learn more
-// about where we are going to deploy
-const SECRET_TOKEN = "x1x;U0K6R[J^(L&u'Hatu{8%Y<,Voj_2\Q!]dLe(Vu^K+.\Yx`g8q?f'%$CI#&Kccy;bJ~}~>pK@UCzR{>Eo2*-ax&T^(jKDH$nY3FK$*.&TJ#rJ9~owMFc;2;uaR["
 
 async function isAuthorized (req, res, next) {
     const authHeader = req.headers.authorization
@@ -14,8 +9,7 @@ async function isAuthorized (req, res, next) {
     }
     try {
         tokenFromClient = authHeader.replace('Bearer ', '')
-        const { tokenString } = jwt.verify(tokenFromClient, SECRET_TOKEN)
-        const userId = await tokenDAO.getUserIdFromToken(tokenString);
+        const userId = await tokenDAO.getUserIdFromToken(tokenFromClient);
         if (!userId) {
             throw new Error("Cannot find token from provided token string")
         }
@@ -25,7 +19,7 @@ async function isAuthorized (req, res, next) {
             throw new Error("Cannot find user by user ID");
         }
         
-        req.tokenString = tokenString;
+        req.tokenString = tokenFromClient;
         req.user = user;
 
         next()
@@ -43,4 +37,4 @@ async function isAdmin (req, res, next) {
     next()
 }
 
-module.exports = { SECRET_TOKEN, isAuthorized, isAdmin }
+module.exports = { isAuthorized, isAdmin }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1336,11 +1336,6 @@
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
-    "buffer-equal-constant-time": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
-    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -1849,14 +1844,6 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
       "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
-    },
-    "ecdsa-sig-formatter": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
-      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -3402,49 +3389,6 @@
         "minimist": "^1.2.5"
       }
     },
-    "jsonwebtoken": {
-      "version": "8.5.1",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
-      "requires": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "ms": {
-          "version": "2.1.3",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        }
-      }
-    },
-    "jwa": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
-      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
-      "requires": {
-        "buffer-equal-constant-time": "1.0.1",
-        "ecdsa-sig-formatter": "1.0.11",
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
-      "requires": {
-        "jwa": "^1.4.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "kareem": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
@@ -3498,41 +3442,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
-    },
-    "lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-    },
-    "lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-    },
-    "lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-    },
-    "lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
-    "lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -4805,7 +4714,8 @@
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
     },
     "send": {
       "version": "0.17.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "bcrypt": "^5.0.1",
     "dotenv": "^10.0.0",
     "express": "^4.17.1",
-    "jsonwebtoken": "^8.5.1",
     "mongoose": "^5.13.5"
   },
   "devDependencies": {

--- a/restClientTests/login.http
+++ b/restClientTests/login.http
@@ -17,7 +17,7 @@ Content-Type: application/json
 
 {
     "email": "mike@hems.com",
-    "password": "PW123"
+    "password": "PW1234"
 }
 
 ###
@@ -38,12 +38,12 @@ POST http://localhost:5000/login/logout
 
 ###
 POST http://localhost:5000/login/logout
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlblN0cmluZyI6IjllMjQwYmE0LWNmOWYtNDhmOS05MDhiLTJkNjc0MzA1ZjIzZCIsImlhdCI6MTYyODI1NjgxMH0.T1hL6kvOu-9hathvTELqyoCZNx8XCtR5guXGuvlAyeQ
+Authorization: Bearer f4ebdfd8-ca5c-44d7-9667-efa837dc9284
 
 ###
 POST http://localhost:5000/login/password
 content-type: application/json
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlblN0cmluZyI6IjllMjQwYmE0LWNmOWYtNDhmOS05MDhiLTJkNjc0MzA1ZjIzZCIsImlhdCI6MTYyODI1NjgxMH0.T1hL6kvOu-9hathvTELqyoCZNx8XCtR5guXGuvlAyeQ
+Authorization: Bearer 161ce6a9-92a1-4731-a844-d9c2a94b6dfc
 
 {
     "password": "PW1234"

--- a/routes/login.js
+++ b/routes/login.js
@@ -1,11 +1,10 @@
 const { Router } = require("express")
 const router = Router()
 const bcrypt = require("bcrypt")
-const { isAuthorized, SECRET_TOKEN } = require("../middleware/auth")
+const { isAuthorized } = require("../middleware/auth")
 const { handleErrors } = require("../middleware/errorhandler")
 const userDAO = require("../daos/users")
 const tokenDAO = require("../daos/token")
-const jwt = require("jsonwebtoken")
 
 router.post("/signup", async (req, res, next) => {
     const { email, password } = req.body
@@ -56,18 +55,8 @@ router.post("/", async (req, res, next) => {
                 res.sendStatus(401)
             }
             if (bcryptRes) {
-
                 const tokenString = await tokenDAO.getTokenForUserId(foundUser._id.toHexString());
-                const tokenToSave = { tokenString };
-                const createdToken = jwt.sign(tokenToSave, SECRET_TOKEN);
-                res.status(200).send({token: createdToken});
-                // jwt.sign({
-                //     email: foundUser.email,
-                //     roles: foundUser.roles,
-                //     _id: foundUser._id
-                // }, SECRET_TOKEN, (err, token) => {
-                //     res.json({token})
-                // });
+                res.status(200).send({ token: tokenString });
             }
             else {
                 res.sendStatus(401)


### PR DESCRIPTION
JWT was not necessary since we opted to store tokens in the database.  The idea is that upon successful login, we pass a token in the response body that looks like this:  { token: 161ce6a9-92a1-4731-a844-d9c2a94b6dfc }  This is a random string created by uuid.  When the client makes a subsequent request, they add this to the header:

Authorization: Bearer 161ce6a9-92a1-4731-a844-d9c2a94b6dfc

We then look up that token in the database, find the associated userId, then load the user.

No need to complicate by adding jwt.  I got marked off on my homework for doing this, so I'm eager to correct it!