### PR TITLE
Updated isAdmin and routes to remove redundant 403 check

### DIFF
--- a/globalConfig.json
+++ b/globalConfig.json
@@ -1,1 +1,1 @@
-{"mongoUri":"mongodb://127.0.0.1:60820/"}
+{"mongoUri":"mongodb://127.0.0.1:57965/"}

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -21,6 +21,9 @@ async function isAuthorized (req, res, next) {
         
         req.tokenString = tokenFromClient;
         req.user = user;
+        if (req.user.roles.includes("admin")) {
+            req.user.isAdmin = true
+        }        
 
         next()
     }
@@ -31,8 +34,9 @@ async function isAuthorized (req, res, next) {
 }
 
 async function isAdmin (req, res, next) {
-    if (req.user.roles.includes("admin")) {
-        req.user.isAdmin = true
+    if (!req.user.isAdmin) {
+        res.sendStatus(403);
+        return;
     }
     next()
 }

--- a/models/movie.js
+++ b/models/movie.js
@@ -7,8 +7,7 @@ const movieSchema = new mongoose.Schema({
   synopsis: { type: String, required: true },
   rating: { type: String, required: true },
   releaseYear: { type: Number, required: true },
-  moviePicUrl: { type: String },
-  theaters: { type: [{ type: mongoose.Schema.Types.ObjectId, ref: 'theaters' }] }
+  moviePicUrl: { type: String }
 });
 
 movieSchema.index({ title: 'text', genre: 'text', synopsis: 'text' });

--- a/models/user.js
+++ b/models/user.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const userSchema = new mongoose.Schema({
   password:  { type: String, required: true},
   email: { type: String, unique: true, required: true},
+  username: { type: String, unique: true },
   roles: { type: [String], required: true }
 });
 

--- a/models/user.js
+++ b/models/user.js
@@ -3,7 +3,6 @@ const mongoose = require('mongoose');
 const userSchema = new mongoose.Schema({
   password:  { type: String, required: true},
   email: { type: String, unique: true, required: true},
-  username: { type: String, unique: true },
   roles: { type: [String], required: true }
 });
 

--- a/restClientTests/movies.http
+++ b/restClientTests/movies.http
@@ -1,1 +1,5 @@
 GET http://localhost:5000/movies?perPage=10
+
+###
+
+GET mongodb+srv://hems:hdjhmVi7esVA@cluster21.0hrdz.mongodb.net/movieratings?retryWrites=true&w=majority/movies?perPage=10

--- a/routes/movies.test.js
+++ b/routes/movies.test.js
@@ -1,0 +1,212 @@
+const request = require("supertest");
+
+const server = require("../server");
+const testUtils = require('../test-utils');
+
+const User = require('../models/user');
+const Movie = require('../models/movie');
+const Theater = require('../models/theater');
+
+describe("/movies", () => {
+    beforeAll(testUtils.connectDB);
+    afterAll(testUtils.stopDB);
+  
+    afterEach(testUtils.clearDB);
+
+    const movie1 = {
+        title: "Movie 1",
+        actors: ["John Doe", "Jane Doe"],
+        genre: ["Drama", "Musical"],
+        synopsis: "Story about John and Jane",
+        releaseYear: 2020,
+        rating: "PG",
+        moviePicUrl: "https://pictures.url/movie1.png"
+    };
+    const movie2 = {
+        title: "Movie 2",
+        actors: ["Actor One", "Actor Two"],
+        genre: ["Crime", "Drama"],
+        synopsis: "Movie two synopsis.",
+        releaseYear: 2021,
+        rating: "R",
+        moviePicUrl: "https://pictures.url/movie2.png"
+    };
+
+    beforeEach(async () => {
+        const theater1 = {
+            name: "AMC",
+            movies: [],
+            zip: 98004
+        }
+        savedMovies = (await Movie.insertMany([movie1, movie2])).map(i => i.toJSON());
+        theater1.movies.push(savedMovies[0]._id)
+        savedTheater = await Theater.create(theater1);
+    });
+    
+    describe('Before login', () => {
+        describe('POST /', () => {
+            it('should send 401 without a token', async () => {
+                const res = await request(server).post("/movies").send(movie1);
+                expect(res.statusCode).toEqual(401);
+            });
+              it('should send 401 with a bad token', async () => {
+                const res = await request(server)
+                    .post("/movies")
+                    .set('Authorization', 'Bearer BAD')
+                    .send(movie1);
+                expect(res.statusCode).toEqual(401);
+            });
+        });
+        describe('PUT /:id', () => {
+            it('should send 401 without a token', async () => {
+                const res = await request(server)
+                    .put("/movies/" + savedMovies[1]._id)
+                    .send({ ...movie1, releaseYear: movie1.releaseYear++ });
+                expect(res.statusCode).toEqual(401);
+            });
+            it('should send 401 with a bad token', async () => {
+                const res = await request(server)
+                    .put("/movies/" + savedMovies[1]._id)
+                    .set('Authorization', 'Bearer BAD')
+                    .send({ ...movie1, releaseYear: movie1.releaseYear++ });
+                expect(res.statusCode).toEqual(401);
+            });
+        });
+        describe('DELETE /:id', () => {
+            it('should send 401 without a token', async () => {
+                const res = await request(server).delete("/movies/" + savedMovies[1]._id).send();
+                expect(res.statusCode).toEqual(401);
+            });
+            it('should send 401 with a bad token', async () => {
+                const res = await request(server)
+                  .delete("/movies/" + savedMovies[1]._id)
+                  .set('Authorization', 'Bearer BAD')
+                  .send();
+                expect(res.statusCode).toEqual(401);
+            });
+        });
+        describe('GET /', () => {
+            it('should send an array of movie without login', async () => {
+                const res = await request(server).get("/movies");
+                expect(res.statusCode).toEqual(200);
+                expect(res.body).toHaveLength(2);
+                res.body.forEach(element => {
+                    expect(element.reviewCount === 0);
+                    expect(element.averageScore === 0);
+                });
+            });
+        });
+        describe('GET /:id', () => {
+            it('should send 200 and movie detail with a correct movie ID', async () => {
+                const res = await request(server).get("/movies/" + savedMovies[1]._id);
+                expect(res.statusCode).toEqual(200);
+                expect(res.body).toMatchObject({ title: "Movie 2" });
+            });
+            it('should send 404 with wrong movie ID', async () => {
+                const res = await request(server).get("/movies/12345");
+                expect(res.statusCode).toEqual(404);
+            });
+        });
+        describe("GET /:id/theaters", () => {
+            it('should send an array of theaters', async () => {
+                const res = await request(server).get("/movies/" + savedMovies[0]._id + "/theaters");
+                expect(res.statusCode).toEqual(200);
+                expect(res.body).toHaveLength(1);
+                expect(res.body[0]._id).toEqual(savedTheater._id.toString());
+            });
+            it('should send 404 with wrong movie ID', async () => {
+                const res = await request(server).get("/movies/12345/theaters");
+                expect(res.statusCode).toEqual(404);
+            });
+        });
+        describe("GET /search", () => {
+            it("should return one matching movie", async () => {
+                const res = await request(server).get("/movies/search?query=John");
+                expect(res.statusCode).toEqual(200);
+                expect(res.body[0]).toMatchObject({title: 'Movie 1'});
+            });
+        });
+        it("should return two matching movies", async () => {
+            const res = await request(server).get("/movies/search?query=Drama");
+            expect(res.statusCode).toEqual(200);
+            expect(res.body[0]).toMatchObject({ title: 'Movie 1' });
+            expect(res.body[1]).toMatchObject({ title: 'Movie 2' });
+        });
+        it("should return an empty array if no match", async () => {
+            const res = await request(server).get("/movies/search?query=randomSearchTerm");
+            expect(res.statusCode).toEqual(200);
+            expect(res.body).toHaveLength(0);
+        });
+    });
+
+    describe('After login', () => {
+        const testUser = {
+            email: 'testuser@mail.com',
+            password: 'somepassword'
+        };
+        const testMovie = {
+            title: "Test Movie",
+            actors: ["Test 1", "Test 2"],
+            genre: ["Comedy"],
+            synopsis: "A great movie",
+            releaseYear: 2019,
+            rating: "G",
+            moviePicUrl: "https://pictures.url/testmovie.png"
+        };
+        let token1;
+        beforeEach(async () => {
+            await request(server).post("/login/signup").send(testUser);
+            const resp = await request(server).post("/login").send(testUser);
+            token1 = resp.body.token;
+        });
+
+        describe('POST /', () => {
+            it('should send 200 and create movie object', async () => {
+                const res = await request(server)
+                    .post("/movies")
+                    .set('Authorization', 'Bearer ' + token1)
+                    .send(testMovie);
+                expect(res.statusCode).toEqual(200);
+                const newMovie = await Movie.findOne({ _id: res.body._id });
+                expect(newMovie).toMatchObject({ title: 'Test Movie' });
+            });
+        });
+        describe('PUT /:id', () => {
+            it("should reject a bad id", async () => {
+                const res = await request(server)
+                    .put("/movies/12345")
+                    .set('Authorization', 'Bearer ' + token1)
+                    .send({ movie1 });
+                expect(res.statusCode).toEqual(400);
+            });
+            it("should update a movie", async () => {
+                const res = await request(server)
+                    .put("/movies/" + savedMovies[1]._id)
+                    .set('Authorization', 'Bearer ' + token1)
+                    .send({ ...movie1, releaseYear: movie1.releaseYear++ });
+                expect(res.statusCode).toEqual(200);
+                const updatedMovie = await Movie.findById(savedMovies[1]._id).lean();
+                expect(updatedMovie.releaseYear).toEqual(2022);
+            });
+        });
+        describe('DELETE /:id', () => {
+            it("should reject a bad id", async () => {
+                const res = await request(server)
+                    .delete("/movies/12345")
+                    .set('Authorization', 'Bearer ' + token1)
+                    .send();
+                expect(res.statusCode).toEqual(400);
+            });
+            it("should delete a movie", async () => {
+                const { _id } = savedMovies[1];
+                const res = await request(server)
+                    .delete("/movies/" + _id)
+                    .set('Authorization', 'Bearer ' + token1)
+                    .send();
+                expect(res.statusCode).toEqual(200);
+                const deletedMovie = await Movie.findOne({ _id });
+                expect(deletedMovie).toBeNull();
+            });
+        });
+    });
+});

--- a/routes/reviews.js
+++ b/routes/reviews.js
@@ -27,39 +27,13 @@ router.post("/", isAuthorized, async (req, res, next) => {
   }
 });
 
-//
-// BACKLOG PUT	/reviews/:id
-// 
-// router.put("/:id", isAuthorized, isAdmin, async (req, res, next) => {
-//   const reviewId = req.params.id;
-//   const isAdmin = req.user.isAdmin;
-//   try {
-//     if (isAdmin) {
-//       const reviewUpdated = await reviewsDAO.updateReview(reviewId, req.body);
-//       if (reviewUpdated) {
-//         res.sendStatus(success ? 200 : 400);
-//       }
-//     } else {
-//       res.status(403).send('Forbidden - Admin role required');
-//     }
-//   } catch (e) {
-//     next(e);
-//   }
-// });
-
-
 // DELETE	/reviews/:id
 router.delete("/:id", isAuthorized, isAdmin, async (req, res, next) => {
   const reviewId = req.params.id;
-  const isAdmin = req.user.isAdmin;
   try {
-    if (isAdmin) {
-      const reviewDeleted = await reviewsDAO.deleteReview(reviewId);
-      if (reviewDeleted) {
-        res.sendStatus(success ? 200 : 400);
-      }
-    } else {
-      res.status(403).send('Forbidden - Admin role required');
+    const reviewDeleted = await reviewsDAO.deleteReview(reviewId);
+    if (reviewDeleted) {
+      res.sendStatus(success ? 200 : 400);
     }
   } catch (e) {
     next(e);

--- a/routes/theaters.js
+++ b/routes/theaters.js
@@ -48,17 +48,12 @@ router.use(isAuthorized);
 // Create theater (admin privileges required)
 router.post('/', isAdmin, async (req, res, next) => {
   const theater = req.body;
-  const isAdmin = req.user.isAdmin;
   if (!theater || JSON.stringify(theater) === '{}') {
     res.status(400).send('Theater is required');
   } else {
       try {
-        if (isAdmin) {
-          const savedTheater = await theaterDAO.createTheater(theater);
-          res.json(savedTheater); 
-        } else {
-          res.status(403).send('Unauthorized');
-        }
+        const savedTheater = await theaterDAO.createTheater(theater);
+        res.json(savedTheater); 
       } catch (e) {
         next(e);
       } 
@@ -68,18 +63,13 @@ router.post('/', isAdmin, async (req, res, next) => {
 // Update theater (admin privileges required)
 router.put('/:id', isAdmin, async (req, res, next) => {
   const theaterId = req.params.id;
-  const isAdmin = req.user.isAdmin;
   try {
-    if (isAdmin) { 
       const updatedTheater = await theaterDAO.updateTheaterById(theaterId, req.body);
       if (updatedTheater) {
         res.status(200).send('Successfully updated');
       } else {
         res.sendStatus(400);
       }
-    } else {
-      res.status(403).send('Unauthorized');
-    }
   } catch (e) {
     next(e);
   }
@@ -87,17 +77,12 @@ router.put('/:id', isAdmin, async (req, res, next) => {
 
 // Delete theater (admin privileges required)
 router.delete('/:id', isAdmin, async (req, res, next) => {
-  const isAdmin = req.user.isAdmin;
   try { 
-    if (isAdmin) {  
-      const theater = await theaterDAO.deleteTheaterById(req.params.id);
-      if (theater) {
-        res.status(200).send('Successfully deleted');
-      } else {
-        res.sendStatus(400);
-      }
+    const theater = await theaterDAO.deleteTheaterById(req.params.id);
+    if (theater) {
+      res.status(200).send('Successfully deleted');
     } else {
-      res.status(403).send('Unauthorized');
+      res.sendStatus(400);
     }
   } catch (e) {
     next(e);


### PR DESCRIPTION
I made an update to the isAdmin middleware to automatically return a 403, so I also cleaned up code in the reviews and theaters routes that checked this and returned a 403.  This was the repetitive code that Joel marked me off for on a previous assignment.  After this cleanup, just including the isAdmin middleware on the route will automatically return the 403.  The isAuthorized middleware will add the req.user.isAdmin if appropriate.